### PR TITLE
Fix for Mixed Content Errors

### DIFF
--- a/src/webapp/api/timeline-api.js
+++ b/src/webapp/api/timeline-api.js
@@ -279,7 +279,7 @@
         
         var url = useLocalResources ?
             "http://127.0.0.1:9999/ajax/api/simile-ajax-api.js?bundle=false" :
-            "http://api.simile-widgets.org/ajax/" + simile_ajax_ver + "/simile-ajax-api.js";
+            "//api.simile-widgets.org/ajax/" + simile_ajax_ver + "/simile-ajax-api.js";
         if (typeof Timeline_ajax_url == "string") {
            url = Timeline_ajax_url;
         }

--- a/src/webapp/styles.css
+++ b/src/webapp/styles.css
@@ -1,4 +1,4 @@
-@import url("http://www.simile-widgets.org/styles/common.css");
+@import url("//www.simile-widgets.org/styles/common.css");
 
 .timeline-default {
     font-family: Trebuchet MS, Helvetica, Arial, sans serif;


### PR DESCRIPTION
**What does this PR do?**
This code clears mixed content errors during the load of the Simile Timeline API.

**Helpful background context**
If a developer was running off an https served website and using a modern browser (such as Chromium or Brave), hard coded http URLs were causing CSS related rendering problems and a failure to load the Timeline library. These errors occurred because the browser was automatically blocking mixed content loading. By changing loading statements to protocol agnostic URLs the errors can be avoiding while still allowing Timeline to run over either http and https.

This PR has the minimum changes required to correct the errors and allow Timeline to load and render properly. I will submit an additional PR, with many more code changes, that updates the documentation and addresses other issues in the code with mixed content.

**What are the relevant tickets?**
https://groups.google.com/g/simile-widgets/c/8MoBsyyY5v4

**Includes new or updated dependencies?**
NO